### PR TITLE
Fragile data in response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ zf-mkdoc-theme/
 clover.xml
 coveralls-upload.json
 zf-mkdoc-theme.tgz
+/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ zf-mkdoc-theme/
 clover.xml
 coveralls-upload.json
 zf-mkdoc-theme.tgz
-/nbproject/private/

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -126,8 +126,6 @@ class ProblemDetailsResponseFactory
         'application/*+xml',
     ];
 
-    const DEFAULT_NON_PROBLEM_DETAILS_MESSAGE = 'Internal Server Error';
-
     /**
      * Factory for generating an empty response body.
      *

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -168,16 +168,31 @@ class ProblemDetailsResponseFactory
     private $response;
 
     /**
+     * Flag to enable show exception message in detail field.
+     *
+     * Disabled by default for security reasons.
+     *
      * @var bool
      */
     private $showNonProblemDetailsMessage;
+
+    /**
+     * Default detail field value. Will be visible when
+     * $showNonProblemDetailsMessage disabled.
+     *
+     * Empty string by default
+     *
+     * @var string
+     */
+    private $defaultDetailMessage;
 
     public function __construct(
         bool $isDebug = self::EXCLUDE_THROWABLE_DETAILS,
         int $jsonFlags = null,
         ResponseInterface $response = null,
         callable $bodyFactory = null,
-        bool $showNonProblemDetailsMessage = false
+        bool $showNonProblemDetailsMessage = false,
+        string $defaultDetailMessage = ''
     ) {
         $this->isDebug = $isDebug;
         $this->jsonFlags = $jsonFlags
@@ -185,6 +200,7 @@ class ProblemDetailsResponseFactory
         $this->response = $response ?: new Response();
         $this->bodyFactory = $bodyFactory ?: Closure::fromCallable([$this, 'generateStream']);
         $this->showNonProblemDetailsMessage = $showNonProblemDetailsMessage;
+        $this->defaultDetailMessage = $defaultDetailMessage;
     }
 
     public function createResponse(
@@ -231,7 +247,7 @@ class ProblemDetailsResponseFactory
             );
         }
 
-        $detail = $this->isDebug || $this->showNonProblemDetailsMessage ? $e->getMessage() : '';
+        $detail = $this->isDebug || $this->showNonProblemDetailsMessage ? $e->getMessage() : $this->defaultDetailMessage;
         $additionalDetails = $this->isDebug ? $this->createThrowableDetail($e) : [];
         $code = is_int($e->getCode()) ? $e->getCode() : 0;
 

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -351,7 +351,7 @@ class ProblemDetailsResponseFactory
             ];
         }
 
-        if (!empty($previous)) {
+        if (! empty($previous)) {
             $detail['stack'] = $previous;
         }
 

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -174,11 +174,11 @@ class ProblemDetailsResponseFactory
      *
      * @var bool
      */
-    private $showExceptionDetailsInResponse;
+    private $exceptionDetailsInResponse;
 
     /**
      * Default detail field value. Will be visible when
-     * $showExceptionDetailsInResponse disabled.
+     * $exceptionDetailsInResponse disabled.
      *
      * Empty string by default
      *
@@ -191,7 +191,7 @@ class ProblemDetailsResponseFactory
         int $jsonFlags = null,
         ResponseInterface $response = null,
         callable $bodyFactory = null,
-        bool $showExceptionDetailsInResponse = false,
+        bool $exceptionDetailsInResponse = false,
         string $defaultDetailMessage = ''
     ) {
         $this->isDebug = $isDebug;
@@ -199,7 +199,7 @@ class ProblemDetailsResponseFactory
             ?: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
         $this->response = $response ?: new Response();
         $this->bodyFactory = $bodyFactory ?: Closure::fromCallable([$this, 'generateStream']);
-        $this->showExceptionDetailsInResponse = $showExceptionDetailsInResponse;
+        $this->exceptionDetailsInResponse = $exceptionDetailsInResponse;
         $this->defaultDetailMessage = $defaultDetailMessage;
     }
 
@@ -247,9 +247,9 @@ class ProblemDetailsResponseFactory
             );
         }
 
-        $detail = $this->isDebug || $this->showExceptionDetailsInResponse ? $e->getMessage() : $this->defaultDetailMessage;
+        $detail = $this->isDebug || $this->exceptionDetailsInResponse ? $e->getMessage() : $this->defaultDetailMessage;
         $additionalDetails = $this->isDebug ? $this->createThrowableDetail($e) : [];
-        $code = $this->isDebug || $this->showExceptionDetailsInResponse ? $this->getThrowableCode($e) : 500;
+        $code = $this->isDebug || $this->exceptionDetailsInResponse ? $this->getThrowableCode($e) : 500;
 
         return $this->createResponse(
             $request,

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -179,7 +179,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $this->assertEquals('first', $payload['exception']['stack'][0]['message']);
     }
 
-    public function testFragileDataInExceptionShouldBeHideInBodyInNoneDebugMode()
+    public function testFragileDataInExceptionMessageShouldBeHiddenInResponseBodyInNoneDebugMode()
     {
         $fragileMessage = 'Your SQL or password here';
         $exception = new \Exception($fragileMessage);

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -127,6 +127,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
         $payload = $this->getPayloadFromResponse($response);
         $this->assertSame(400, $payload['status']);
+        $this->assertSame(400, $response->getStatusCode());
         $this->assertSame('Exception details', $payload['detail']);
         $this->assertSame('Invalid client request', $payload['title']);
         $this->assertSame('https://example.com/api/doc/invalid-client-request', $payload['type']);
@@ -186,7 +187,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $this->assertEquals('first', $payload['exception']['stack'][0]['message']);
     }
 
-    public function testFragileDataInExceptionMessageShouldBeHiddenInResponseBodyInNoneDebugMode()
+    public function testFragileDataInExceptionMessageShouldBeHiddenInResponseBodyInNoDebugMode()
     {
         $fragileMessage = 'Your SQL or password here';
         $exception = new \Exception($fragileMessage);
@@ -194,6 +195,18 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $response = $this->factory->createResponseFromThrowable($this->request->reveal(), $exception);
 
         $this->assertNotContains($fragileMessage, (string) $response->getBody());
+    }
+
+    public function testExceptionCodeShouldBeIgnoredAnd500ServedInResponseBodyInNoDebugMode()
+    {
+        $exception = new \Exception(null, 400);
+
+        $response = $this->factory->createResponseFromThrowable($this->request->reveal(), $exception);
+
+        $payload = $this->getPayloadFromResponse($response);
+
+        $this->assertSame(500, $payload['status']);
+        $this->assertSame(500, $response->getStatusCode());
     }
 
     public function testFragileDataInExceptionMessageShouldBeVisibleInResponseBodyInNoneDebugModeWhenAllowToShowByFlag()

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -13,12 +13,14 @@ use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Zend\ProblemDetails\Exception\InvalidResponseBodyException;
 use Zend\ProblemDetails\Exception\ProblemDetailsException;
-use Zend\ProblemDetails\ProblemDetailsResponse;
 use Zend\ProblemDetails\ProblemDetailsResponseFactory;
 
 class ProblemDetailsResponseFactoryTest extends TestCase
 {
     use ProblemDetailsAssertionsTrait;
+
+    private $request;
+    private $factory;
 
     protected function setUp() : void
     {
@@ -175,5 +177,15 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $this->assertInternalType('array', $payload['exception']['stack']);
         $this->assertEquals(101010, $payload['exception']['stack'][0]['code']);
         $this->assertEquals('first', $payload['exception']['stack'][0]['message']);
+    }
+
+    public function testFragileDataInExceptionShouldBeHideInBodyInNoneDebugMode()
+    {
+        $fragileMessage = 'Your SQL or password here';
+        $exception = new \Exception($fragileMessage);
+
+        $response = $this->factory->createResponseFromThrowable($this->request->reveal(), $exception);
+
+        $this->assertNotContains($fragileMessage, (string) $response->getBody());
     }
 }

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -188,4 +188,16 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
         $this->assertNotContains($fragileMessage, (string) $response->getBody());
     }
+
+    public function testFragileDataInExceptionMessageShouldBeVisibleInResponseBodyInNoneDebugModeWhenAllowToShowByFlag()
+    {
+        $fragileMessage = 'Your SQL or password here';
+        $exception = new \Exception($fragileMessage);
+
+        $factory = new ProblemDetailsResponseFactory(false, null, null, null, true);
+
+        $response = $factory->createResponseFromThrowable($this->request->reveal(), $exception);
+
+        $this->assertContains($fragileMessage, (string) $response->getBody());
+    }
 }

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -19,7 +19,14 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 {
     use ProblemDetailsAssertionsTrait;
 
+    /**
+     * @var ServerRequestInterface
+     */
     private $request;
+
+    /**
+     * @var ProblemDetailsResponseFactory
+     */
     private $factory;
 
     protected function setUp() : void
@@ -198,6 +205,21 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
         $response = $factory->createResponseFromThrowable($this->request->reveal(), $exception);
 
-        $this->assertContains($fragileMessage, (string) $response->getBody());
+        $payload = $this->getPayloadFromResponse($response);
+
+        $this->assertSame($fragileMessage, $payload['detail']);
+    }
+
+    public function testCustomDetailMessageShouldBeVisible()
+    {
+        $detailMessage = 'Custom detail message';
+
+        $factory = new ProblemDetailsResponseFactory(false, null, null, null, false, $detailMessage);
+
+        $response = $factory->createResponseFromThrowable($this->request->reveal(), new \Exception());
+
+        $payload = $this->getPayloadFromResponse($response);
+
+        $this->assertSame($detailMessage, $payload['detail']);
     }
 }


### PR DESCRIPTION
I wrote about this here 

> When ProblemDetailsMiddleware catch exception (for example MySQL connection problem) then we cannot put code of this exception and what is worse **put message from exception to detail**.

I have same problem with apigility and I need to extend it by my own. Unfortunately after data leaks on production enviroment...

Here it's falling test to show how it's dangerous and should be fixed. If we aggre about that I can provide fix for that.