### PR TITLE
Provide a Not Found handler

### DIFF
--- a/docs/book/not-found-handler.md
+++ b/docs/book/not-found-handler.md
@@ -10,14 +10,10 @@ the request's `Accept` header.
 This handler will only return a response if the request's accept header indicates
 that it will accept either JSON or XML.
 
-
 To use this handler in Expressive add it into your pipeline (usually `pipeline.php`)
 immediate before the default `NotFoundHandler`:
 
-
-```
+```php
 $app->pipe(\Zend\ProblemDetails\ProblemDetailsNotFoundHandler::class);
 $app->pipe(NotFoundHandler::class);
 ```
-
-

--- a/docs/book/not-found-handler.md
+++ b/docs/book/not-found-handler.md
@@ -1,0 +1,23 @@
+# Not Found Handler
+
+This library provides a Not Found handler so that returned 404 responses are in
+the problem details format.
+
+This handler will create a problem details `Response` with a `404` status code and
+a problem details body that will be rendered in either JSON or XML as required by
+the request's `Accept` header.
+
+This handler will only return a response if the request's accept header indicates
+that it will accept either JSON or XML.
+
+
+To use this handler in Expressive add it into your pipeline (usually `pipeline.php`)
+immediate before the default `NotFoundHandler`:
+
+
+```
+$app->pipe(\Zend\ProblemDetails\ProblemDetailsNotFoundHandler::class);
+$app->pipe(NotFoundHandler::class);
+```
+
+

--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -280,3 +280,22 @@ $app->post('/api/domain/transaction', [
     DomainTransactionMiddleware::class,
 ]);
 ```
+
+### Not Found handling
+
+When writing APIs you may also want 404 responses be in the accepted content-type.
+This package provides `ProblemDetailsNotFoundHandler` which will return a
+problem details `Response` with a `404` status if the request can accept either
+JSON or XML.
+
+To use this handler in Expressive add it into your pipeline immediate before the 
+default `NotFoundHandler`:
+
+```
+$app->pipe(\Zend\ProblemDetails\ProblemDetailsNotFoundHandler::class);
+$app->pipe(NotFoundHandler::class);
+```
+
+
+
+

--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -291,11 +291,7 @@ JSON or XML.
 To use this handler in Expressive add it into your pipeline immediate before the 
 default `NotFoundHandler`:
 
-```
+```php
 $app->pipe(\Zend\ProblemDetails\ProblemDetailsNotFoundHandler::class);
 $app->pipe(NotFoundHandler::class);
 ```
-
-
-
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ pages:
         - "Generating Responses": response.md
         - "Exceptions": exception.md
         - "Error Handling Middleware": middleware.md
+        - "Not Found Handler": not-found-handler.md
 site_name: Problem Details
 site_description: 'Problem Details for PSR-7 Applications'
 repo_url: 'https://github.com/zendframework/zend-problem-details'

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -32,6 +32,7 @@ class ConfigProvider
         return [
             'factories'  => [
                 ProblemDetailsMiddleware::class => ProblemDetailsMiddlewareFactory::class,
+                ProblemDetailsNotFoundHandler::class => ProblemDetailsNotFoundHandlerFactory::class,
                 ProblemDetailsResponseFactory::class => ProblemDetailsResponseFactoryFactory::class,
             ],
         ];

--- a/src/ProblemDetailsNotFoundHandler.php
+++ b/src/ProblemDetailsNotFoundHandler.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
+ */
+
 namespace Zend\ProblemDetails;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
@@ -16,7 +22,7 @@ class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
     private $responseFactory;
 
     /**
-     * @param ProblemDetailsResponseFactory $responseFactory Factory to create a response to
+     * @param null|ProblemDetailsResponseFactory $responseFactory Factory to create a response to
      *     update and return when returning an 404 response.
      */
     public function __construct(ProblemDetailsResponseFactory $responseFactory = null)
@@ -48,7 +54,7 @@ class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
     /**
      * Can the middleware act as an error handler?
      *
-     * Returns a boolean false if negotiation fails.
+     * @return boolean false if negotiation fails.
      */
     private function canActAsErrorHandler(ServerRequestInterface $request) : bool
     {

--- a/src/ProblemDetailsNotFoundHandler.php
+++ b/src/ProblemDetailsNotFoundHandler.php
@@ -32,10 +32,6 @@ class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
 
     /**
      * Creates and returns a 404 response.
-     *
-     * @param ServerRequestInterface $request Ignored.
-     * @param DelegateInterface $delegate Ignored.
-     * @return ResponseInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
@@ -53,8 +49,6 @@ class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
 
     /**
      * Can the middleware act as an error handler?
-     *
-     * @return boolean false if negotiation fails.
      */
     private function canActAsErrorHandler(ServerRequestInterface $request) : bool
     {

--- a/src/ProblemDetailsNotFoundHandler.php
+++ b/src/ProblemDetailsNotFoundHandler.php
@@ -33,7 +33,7 @@ class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
     /**
      * Creates and returns a 404 response.
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface
     {
         // If we cannot provide a representation, act as a no-op.
         if (! $this->canActAsErrorHandler($request)) {

--- a/src/ProblemDetailsNotFoundHandler.php
+++ b/src/ProblemDetailsNotFoundHandler.php
@@ -43,7 +43,7 @@ class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
         return $this->responseFactory->createResponse(
             $request,
             404,
-            sprintf("Cannot %s %s!", $request->getMethod(), (string) $request->getUri())
+            sprintf('Cannot %s %s!', $request->getMethod(), (string) $request->getUri())
         );
     }
 

--- a/src/ProblemDetailsNotFoundHandler.php
+++ b/src/ProblemDetailsNotFoundHandler.php
@@ -1,0 +1,60 @@
+<?php
+namespace Zend\ProblemDetails;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
+use Negotiation\Negotiator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Stratigility\Delegate\CallableDelegateDecorator;
+
+class ProblemDetailsNotFoundHandler implements ServerMiddlewareInterface
+{
+    /**
+     * @var ProblemDetailsResponseFactory
+     */
+    private $responseFactory;
+
+    /**
+     * @param ProblemDetailsResponseFactory $responseFactory Factory to create a response to
+     *     update and return when returning an 404 response.
+     */
+    public function __construct(ProblemDetailsResponseFactory $responseFactory = null)
+    {
+        $this->responseFactory = $responseFactory ?: new ProblemDetailsResponseFactory();
+    }
+
+    /**
+     * Creates and returns a 404 response.
+     *
+     * @param ServerRequestInterface $request Ignored.
+     * @param DelegateInterface $delegate Ignored.
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        // If we cannot provide a representation, act as a no-op.
+        if (! $this->canActAsErrorHandler($request)) {
+            return $delegate->process($request);
+        }
+
+        return $this->responseFactory->createResponse(
+            $request,
+            404,
+            sprintf("Cannot %s %s!", $request->getMethod(), (string) $request->getUri())
+        );
+    }
+
+    /**
+     * Can the middleware act as an error handler?
+     *
+     * Returns a boolean false if negotiation fails.
+     */
+    private function canActAsErrorHandler(ServerRequestInterface $request) : bool
+    {
+        $accept = $request->getHeaderLine('Accept') ?: '*/*';
+
+        return null !== (new Negotiator())
+            ->getBest($accept, ProblemDetailsResponseFactory::NEGOTIATION_PRIORITIES);
+    }
+}

--- a/src/ProblemDetailsNotFoundHandlerFactory.php
+++ b/src/ProblemDetailsNotFoundHandlerFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\ProblemDetails;
+
+use Psr\Container\ContainerInterface;
+
+class ProblemDetailsNotFoundHandlerFactory
+{
+    public function __invoke(ContainerInterface $container) : ProblemDetailsNotFoundHandler
+    {
+        return $container->has(ProblemDetailsResponseFactory::class)
+            ? new ProblemDetailsNotFoundHandler($container->get(ProblemDetailsResponseFactory::class))
+            : new ProblemDetailsNotFoundHandler();
+    }
+}

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -27,7 +27,7 @@ class ConfigProviderTest extends TestCase
         $this->assertArrayHasKey('factories', $dependencies);
 
         $factories = $dependencies['factories'];
-        $this->assertCount(2, $factories);
+        $this->assertCount(3, $factories);
         $this->assertArrayHasKey(ProblemDetailsMiddleware::class, $factories);
         $this->assertArrayHasKey(ProblemDetailsResponseFactory::class, $factories);
 

--- a/test/ProblemDetailsNotFoundHandlerFactoryTest.php
+++ b/test/ProblemDetailsNotFoundHandlerFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\ProblemDetails;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\ProblemDetails\ProblemDetailsNotFoundHandler;
+use Zend\ProblemDetails\ProblemDetailsNotFoundHandlerFactory;
+use Zend\ProblemDetails\ProblemDetailsResponseFactory;
+
+class ProblemDetailsNotFoundHandlerFactoryTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->factory = new ProblemDetailsNotFoundHandlerFactory();
+    }
+
+    public function testCreatesNotFoundHandlerWithoutResponseFactoryIfServiceDoesNotExist() : void
+    {
+        $this->container->has(ProblemDetailsResponseFactory::class)->willReturn(false);
+        $this->container->get(ProblemDetailsResponseFactory::class)->shouldNotBeCalled();
+
+        $notFoundHandler = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(ProblemDetailsNotFoundHandler::class, $notFoundHandler);
+        $this->assertAttributeInstanceOf(
+            ProblemDetailsResponseFactory::class,
+            'responseFactory',
+            $notFoundHandler
+        );
+    }
+
+    public function testCreatesNotFoundHandlerUsingResponseFactoryService() : void
+    {
+        $responseFactory = $this->prophesize(ProblemDetailsResponseFactory::class)->reveal();
+        $this->container->has(ProblemDetailsResponseFactory::class)->willReturn(true);
+        $this->container->get(ProblemDetailsResponseFactory::class)->willReturn($responseFactory);
+
+        $notFoundHandler = ($this->factory)($this->container->reveal());
+
+        $this->assertInstanceOf(ProblemDetailsNotFoundHandler::class, $notFoundHandler);
+        $this->assertAttributeSame(
+            $responseFactory,
+            'responseFactory',
+            $notFoundHandler
+        );
+    }
+}

--- a/test/ProblemDetailsNotFoundHandlerTest.php
+++ b/test/ProblemDetailsNotFoundHandlerTest.php
@@ -21,7 +21,7 @@ class ProblemDetailsNotFoundHandlerTest extends TestCase
 {
     use ProblemDetailsAssertionsTrait;
 
-    public function acceptHeaders()
+    public function acceptHeaders() : array
     {
         return [
             'application/json' => ['application/json', 'application/problem+json'],
@@ -35,7 +35,7 @@ class ProblemDetailsNotFoundHandlerTest extends TestCase
     public function testReturnsResponseWith404StatusAndErrorMessageInBodyWithDefaultFactory(
         string $acceptHeader,
         string $expectedHeader
-    ) {
+    ) : void {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn('POST');
         $request->getHeaderLine('Accept')->willReturn($acceptHeader);
@@ -63,7 +63,7 @@ class ProblemDetailsNotFoundHandlerTest extends TestCase
     /**
      * @dataProvider acceptHeaders
      */
-    public function testResponseFactoryPassedInConstructorGeneratesTheReturnedResponse(string $acceptHeader)
+    public function testResponseFactoryPassedInConstructorGeneratesTheReturnedResponse(string $acceptHeader) : void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn('POST');

--- a/test/ProblemDetailsNotFoundHandlerTest.php
+++ b/test/ProblemDetailsNotFoundHandlerTest.php
@@ -41,7 +41,7 @@ class ProblemDetailsNotFoundHandlerTest extends TestCase
             "status" => 404,
             "detail" => "Cannot POST https://example.com/foo!",
         ];
-        
+
         $this->assertSame($expectedBody, $this->getPayloadFromResponse($returnedResponse));
         $this->assertSame(404, $returnedResponse->getStatusCode());
         $this->assertSame('application/problem+json', $returnedResponse->getHeaderLine('Content-Type'));

--- a/test/ProblemDetailsNotFoundHandlerTest.php
+++ b/test/ProblemDetailsNotFoundHandlerTest.php
@@ -86,4 +86,26 @@ class ProblemDetailsNotFoundHandlerTest extends TestCase
             $notFoundHandler->process($request->reveal(), $this->prophesize(DelegateInterface::class)->reveal())
         );
     }
+
+    public function testDelegateIsCalledIfAcceptHeaderIsUnacceptable() : void
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getHeaderLine('Accept')->willReturn('text/html');
+        $request->getUri()->willReturn('https://example.com/foo');
+
+        $response = $this->prophesize(ResponseInterface::class);
+
+        $delegate = $this->prophesize(DelegateInterface::class);
+        $delegate->process($request->reveal())->will([$response, 'reveal']);
+
+        $responseFactory = $this->prophesize(ProblemDetailsResponseFactory::class);
+
+        $notFoundHandler = new ProblemDetailsNotFoundHandler($responseFactory->reveal());
+
+        $this->assertSame(
+            $response->reveal(),
+            $notFoundHandler->process($request->reveal(), $delegate->reveal())
+        );
+    }
 }

--- a/test/ProblemDetailsNotFoundHandlerTest.php
+++ b/test/ProblemDetailsNotFoundHandlerTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\ProblemDetails;
+
+use ErrorException;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Zend\ProblemDetails\ProblemDetailsNotFoundHandler;
+use Zend\ProblemDetails\ProblemDetailsResponseFactory;
+
+class ProblemDetailsNotFoundHandlerTest extends TestCase
+{
+    use ProblemDetailsAssertionsTrait;
+
+    public function testReturnsResponseWith404StatusAndErrorMessageInBodyWithDefaultFactory()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getHeaderLine('Accept')->willReturn('application/json');
+        $request->getUri()->willReturn('https://example.com/foo');
+
+        $notFoundHandler = new ProblemDetailsNotFoundHandler();
+
+        $returnedResponse = $notFoundHandler->process(
+            $request->reveal(),
+            $this->prophesize(DelegateInterface::class)->reveal()
+        );
+
+        $expectedBody = [
+            "title" => "Not Found",
+            "type" => "https://httpstatus.es/404",
+            "status" => 404,
+            "detail" => "Cannot POST https://example.com/foo!",
+        ];
+        
+        $this->assertSame($expectedBody, $this->getPayloadFromResponse($returnedResponse));
+        $this->assertSame(404, $returnedResponse->getStatusCode());
+        $this->assertSame('application/problem+json', $returnedResponse->getHeaderLine('Content-Type'));
+    }
+
+    public function testResponseFactoryPassedInConstructorGeneratesTheReturnedResponse()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn('POST');
+        $request->getHeaderLine('Accept')->willReturn('application/json');
+        $request->getUri()->willReturn('https://example.com/foo');
+
+        $response = $this->prophesize(ResponseInterface::class);
+
+        $responseFactory = $this->prophesize(ProblemDetailsResponseFactory::class);
+        $responseFactory->createResponse(
+            Argument::that([$request, 'reveal']),
+            404,
+            'Cannot POST https://example.com/foo!'
+        )->will([$response, 'reveal']);
+
+        $notFoundHandler = new ProblemDetailsNotFoundHandler($responseFactory->reveal());
+
+        $this->assertSame(
+            $response->reveal(),
+            $notFoundHandler->process($request->reveal(), $this->prophesize(DelegateInterface::class)->reveal())
+        );
+    }
+}

--- a/test/ProblemDetailsNotFoundHandlerTest.php
+++ b/test/ProblemDetailsNotFoundHandlerTest.php
@@ -49,10 +49,10 @@ class ProblemDetailsNotFoundHandlerTest extends TestCase
         );
 
         $expectedBody = [
-            "title" => "Not Found",
-            "type" => "https://httpstatus.es/404",
-            "status" => 404,
-            "detail" => "Cannot POST https://example.com/foo!",
+            'title' => 'Not Found',
+            'type' => 'https://httpstatus.es/404',
+            'status' => 404,
+            'detail' => 'Cannot POST https://example.com/foo!',
         ];
 
         $this->assertEquals($expectedBody, $this->getPayloadFromResponse($returnedResponse));


### PR DESCRIPTION
Implement `ProblemDetailsNotFoundHandler` so that an API can send back a problem details response if the request accepts XML or JSON.

Typical usage in Expressive is to add it into your pipeline immediate before the 
default `NotFoundHandler`:

```
$app->pipe(\Zend\ProblemDetails\ProblemDetailsNotFoundHandler::class);
$app->pipe(NotFoundHandler::class);
```
