### PR TITLE
Fixed order of packages in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         "sort-packages": true
     },
     "require": {
+        "php": "^7.1",
         "ext-json": "*",
         "fig/http-message-util": "^1.1.2",
         "http-interop/http-middleware": "^0.4.1",
-        "php": "^7.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "spatie/array-to-xml": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "97e186a86ed566073af857841d37bc6e",
+    "content-hash": "03cf5a164a74a7dfab7b485b437cf55c",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -1973,8 +1973,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-json": "*",
-        "php": "^7.1"
+        "php": "^7.1",
+        "ext-json": "*"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Correct order of packages in require(-dev) section is as follows:
  - php version
  - ext-* - php extensions in alphabetical order
  - packages in alphabetical order