### PR TITLE
Create a response when a resource is in the trace

### DIFF
--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -232,6 +232,13 @@ class ProblemDetailsResponseFactory
             $payload = array_merge($additional, $payload);
         }
 
+        // ensure payload can be json_encoded
+        array_walk_recursive($payload, function (&$value) {
+            if (is_resource($value)) {
+                $value = print_r($value, true) . ' of type ' . get_resource_type($value);
+            }
+        });
+
         return $this->getResponseGenerator($request)($payload);
     }
 

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -229,15 +229,15 @@ class ProblemDetailsResponseFactory
         ];
 
         if ($additional) {
+            // ensure payload can be json_encoded
+            array_walk_recursive($additional, function (&$value) {
+                if (is_resource($value)) {
+                    $value = print_r($value, true) . ' of type ' . get_resource_type($value);
+                }
+            });
             $payload = array_merge($additional, $payload);
         }
 
-        // ensure payload can be json_encoded
-        array_walk_recursive($payload, function (&$value) {
-            if (is_resource($value)) {
-                $value = print_r($value, true) . ' of type ' . get_resource_type($value);
-            }
-        });
 
         return $this->getResponseGenerator($request)($payload);
     }

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -238,7 +238,6 @@ class ProblemDetailsResponseFactory
             $payload = array_merge($additional, $payload);
         }
 
-
         return $this->getResponseGenerator($request)($payload);
     }
 

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -135,6 +135,35 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $this->assertSame('bar', $payload['foo']);
     }
 
+    /**
+     * @dataProvider acceptHeaders
+     */
+    public function testCreateResponseRemovesResourcesFromInputData(string $header, string $expectedType) : void
+    {
+        $this->request->getHeaderLine('Accept')->willReturn($header);
+
+        $fh = fopen(__FILE__, 'r');
+        $response = $this->factory->createResponse(
+            $this->request->reveal(),
+            500,
+            'Unknown error occurred',
+            'Title',
+            'Type',
+            [
+                'args' => [
+                    'resource' => $fh,
+                ]
+            ]
+        );
+        fclose($fh);
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals($expectedType, $response->getHeaderLine('Content-Type'));
+
+        $this->assertNotEmpty((string)$response->getBody(), 'Body is missing');
+    }
+
+
     public function testFactoryRaisesExceptionIfBodyFactoryDoesNotReturnStream() : void
     {
         $this->request->getHeaderLine('Accept')->willReturn('application/json');

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -163,7 +163,6 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $this->assertNotEmpty((string)$response->getBody(), 'Body is missing');
     }
 
-
     public function testFactoryRaisesExceptionIfBodyFactoryDoesNotReturnStream() : void
     {
         $this->request->getHeaderLine('Accept')->willReturn('application/json');


### PR DESCRIPTION
As json_encode() doesn't serialise resources, we need to remove them
from the $additional array where they may be an argument to a method
that is in the stack trace.
