### PR TITLE
 supply JSON_PRETTY_PRINT only on debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ Versions 0.3.0 and prior were released as "weierophinney/problem-details".
   modifies the constructor of `Zend\ProblemDetails\ProblemDetailsNotFoundHandler`;
   the `$responseFactory` argument is now required.
 
+- [#34](https://github.com/zendframework/zend-problem-details/pull/34) updates
+  the default `$jsonFlag` to the `Zend\ProblemDetails\ProblemDetailsResponseFactory`
+  constructor to include `JSON_PRETTY_PRINT` only when the `$isDebug` argument
+  is boolean `true`.
+
 ### Deprecated
 
 - Nothing.
@@ -67,7 +72,7 @@ Versions 0.3.0 and prior were released as "weierophinney/problem-details".
 ### Added
 
 - [#30](https://github.com/zendframework/zend-problem-details/pull/30)
-  adds PSR-15 support. 
+  adds PSR-15 support.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,10 @@ Versions 0.3.0 and prior were released as "weierophinney/problem-details".
   the `$responseFactory` argument is now required.
 
 - [#34](https://github.com/zendframework/zend-problem-details/pull/34) updates
-  the default `$jsonFlag` to the `Zend\ProblemDetails\ProblemDetailsResponseFactory`
-  constructor to include `JSON_PRETTY_PRINT` only when the `$isDebug` argument
-  is boolean `true`.
+  the behavior when passing null as the `$jsonFlag` parameter to the
+  `Zend\ProblemDetails\ProblemDetailsResponseFactory` constructor; in such
+  situations, the default `json_encode()` flags will include `JSON_PRETTY_PRINT`
+  only when the `$isDebug` argument is boolean `true`.
 
 ### Deprecated
 

--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -116,8 +116,11 @@ where:
 - `int $jsonFlags` is an integer bitmask of [JSON encoding
   constants](http://php.net/manual/en/json.constants.php) to use with
   `json_encode()` when generating JSON problem details. If you pass a `null`
-  value, `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE |
-  JSON_PRESERVE_ZERO_FRACTION` will be used.
+  value, and the `$isDebug` flag is true,
+  `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION`
+  will be used; otherwise,
+  `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION`
+  will be used.
 - `bool $exceptionDetailsInResponse` is a flag indicating whether or not to
   include exception details (in particular, the message) when creating the
   problem details response. By default, for non-`ProblemDetailsExceptionInterface`

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -191,8 +191,13 @@ class ProblemDetailsResponseFactory
             return $responseFactory();
         };
         $this->isDebug = $isDebug;
-        $this->jsonFlags = $jsonFlags
-            ?: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
+        if (! $jsonFlags) {
+            $jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
+            if ($isDebug) {
+                $jsonFlags = JSON_PRETTY_PRINT | $jsonFlags;
+            }
+        }
+        $this->jsonFlags = $jsonFlags;
         $this->exceptionDetailsInResponse = $exceptionDetailsInResponse;
         $this->defaultDetailMessage = $defaultDetailMessage;
     }

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -146,7 +146,8 @@ class ProblemDetailsResponseFactory
     /**
      * JSON flags to use when generating JSON response payload.
      *
-     * Defaults to JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+     * Defaults to JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION on non-debug mode
+     * and JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION on debug mode
      *
      * @var int
      */

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -146,8 +146,10 @@ class ProblemDetailsResponseFactory
     /**
      * JSON flags to use when generating JSON response payload.
      *
-     * Defaults to JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION on non-debug mode
-     * and JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION on debug mode
+     * On non-debug mode:
+     * defaults to JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+     * On debug mode:
+     * defaults to JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
      *
      * @var int
      */

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -92,8 +92,8 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->container->get('config')->willReturn([
             'debug' => true,
         ]);
-        $this->container->has(ResponseInterface::class)->willReturn(false);
-        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
+        $this->container->get(ResponseInterface::class)->willReturn(function () {
+        });
 
         $factoryFactory = new ProblemDetailsResponseFactoryFactory();
         $factory = $factoryFactory($this->container->reveal());

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -77,13 +77,32 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
         $this->assertAttributeSame(ProblemDetailsResponseFactory::EXCLUDE_THROWABLE_DETAILS, 'isDebug', $factory);
         $this->assertAttributeSame(
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
             'jsonFlags',
             $factory
         );
 
         $this->assertAttributeInstanceOf(Closure::class, 'responseFactory', $factory);
         $this->assertResponseFactoryReturns($response, $factory);
+    }
+
+    public function testUsesPrettyPrintFlagOnEnabledDebugMode() : void
+    {
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn([
+            'debug' => true,
+        ]);
+        $this->container->has(ResponseInterface::class)->willReturn(false);
+        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
+
+        $factoryFactory = new ProblemDetailsResponseFactoryFactory();
+        $factory = $factoryFactory($this->container->reveal());
+
+        $this->assertAttributeSame(
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
+            'jsonFlags',
+            $factory
+        );
     }
 
     public function testUsesDebugSettingFromConfigWhenPresent() : void


### PR DESCRIPTION
Implements #4 

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve? #4
  - [x] How will users use the new feature? by set 'debug' config to true, the JSON_PRETTY_PRINT applied when `$jsonFlags` is null
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.