### PR TITLE
Refactors ProblemDetailsResponseFactory to consume a response factory, not prototype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,8 @@
         "willdurand/negotiation": "^2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5.5",
-        "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-diactoros": "^1.4"
+        "phpunit/phpunit": "^7.0.1",
+        "zendframework/zend-coding-standard": "~1.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "446cb87e55543785c6805fc9f946f4ce",
+    "content-hash": "56c3b580292adf9a6cca6f6b74e85886",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -263,23 +263,23 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "abea6694036ab2d818ceb5c80485a24833a0f9cc"
+                "reference": "cb8befcd0c58ccf8baa5491e61a5c1d02a3acbba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/abea6694036ab2d818ceb5c80485a24833a0f9cc",
-                "reference": "abea6694036ab2d818ceb5c80485a24833a0f9cc",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/cb8befcd0c58ccf8baa5491e61a5c1d02a3acbba",
+                "reference": "cb8befcd0c58ccf8baa5491e61a5c1d02a3acbba",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0"
             },
             "require-dev": {
-                "mockery/mockery": "0.9.*",
+                "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^6.3",
                 "spatie/phpunit-snapshot-assertions": "^1.0"
             },
@@ -308,7 +308,7 @@
                 "convert",
                 "xml"
             ],
-            "time": "2017-09-07T17:44:43+00:00"
+            "time": "2018-02-20T15:21:24+00:00"
         },
         {
             "name": "willdurand/negotiation",
@@ -621,16 +621,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
@@ -668,7 +668,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27T17:38:31+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -719,16 +719,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -740,7 +740,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -778,44 +778,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -841,7 +841,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-02-02T07:01:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -933,28 +933,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -969,7 +969,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -978,33 +978,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2018-02-01T13:07:23+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1027,20 +1027,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2018-02-01T13:16:43+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.5",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "83d27937a310f2984fd575686138597147bdc7df"
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/83d27937a310f2984fd575686138597147bdc7df",
-                "reference": "83d27937a310f2984fd575686138597147bdc7df",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
                 "shasum": ""
             },
             "require": {
@@ -1052,15 +1052,15 @@
                 "myclabs/deep-copy": "^1.6.1",
                 "phar-io/manifest": "^1.0.1",
                 "phar-io/version": "^1.0",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-code-coverage": "^6.0",
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
                 "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
@@ -1068,16 +1068,12 @@
                 "sebastian/resource-operations": "^1.0",
                 "sebastian/version": "^2.0.1"
             },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -1085,7 +1081,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -1111,33 +1107,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-17T06:31:19+00:00"
+            "time": "2018-02-26T07:03:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-text-template": "^1.2.1",
                 "sebastian/exporter": "^3.1"
             },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1145,7 +1138,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -1170,7 +1163,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-02-15T05:27:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1219,21 +1212,21 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.2",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "11c07feade1d65453e06df3b3b90171d6d982087"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/11c07feade1d65453e06df3b3b90171d6d982087",
-                "reference": "11c07feade1d65453e06df3b3b90171d6d982087",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^2.0 || ^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
@@ -1279,32 +1272,33 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-01-12T06:34:42+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1329,9 +1323,12 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2018-02-01T13:45:15+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1851,16 +1848,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1897,7 +1894,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -1927,58 +1924,6 @@
                 "zf"
             ],
             "time": "2016-11-09T21:30:43+00:00"
-        },
-        {
-            "name": "zendframework/zend-diactoros",
-            "version": "1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "ed6ce7e2105c400ca10277643a8327957c0384b7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/ed6ce7e2105c400ca10277643a8327957c0384b7",
-                "reference": "ed6ce7e2105c400ca10277643a8327957c0384b7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8",
-                "zendframework/zend-coding-standard": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.7.x-dev",
-                    "dev-develop": "1.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Diactoros\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "PSR HTTP Message implementations",
-            "homepage": "https://github.com/zendframework/zend-diactoros",
-            "keywords": [
-                "http",
-                "psr",
-                "psr-7"
-            ],
-            "time": "2018-01-04T18:21:48+00:00"
         }
     ],
     "aliases": [],

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -9,10 +9,7 @@ For this purpose, this library provides `ProblemDetailsMiddleware`.
 
 This middleware does the following:
 
-- Composes a `ProblemDetailsResponseFactory`; if none is passed during
-  instantiation, one is created with no arguments, defaulting to usage of
-  zend-diactoros for response and response body generation, and defaulting to
-  production settings.
+- Composes a `ProblemDetailsResponseFactory`.
 - Determines if the request accepts JSON or XML; if neither is accepted, it
   simply passes execution to the request handler.
 - Registers a PHP error handler using the current `error_reporting` mask, and
@@ -99,11 +96,11 @@ $middleware->attachListener($listener);
 ## Factory
 
 The `ProblemDetailsMiddleware` ships with a corresponding PSR-11 compatible factory,
-`ProblemDetailsMiddlewareFactory`. This factory looks for a service named
-`Zend\ProblemDetails\ProblemDetailsResponseFactory`; if present, that value is used
-to instantiate the middleware.
+`ProblemDetailsMiddlewareFactory`. This factory uses the service named
+`Zend\ProblemDetails\ProblemDetailsResponseFactory` to instantiate the
+middleware.
 
-For Expressive 2 users, this middleware should be registered automatically with
+For Expressive 2+ users, this middleware should be registered automatically with
 your application on install, assuming you have the zend-component-installer
 plugin in place (it's shipped by default with the Expressive skeleton).
 

--- a/docs/book/quick-start.md
+++ b/docs/book/quick-start.md
@@ -220,7 +220,7 @@ class DomainException extends PhpDomainException implements ProblemDetailsExcept
 {
     use CommonProblemDetailsExceptionTrait;
 
-    public static function create(string $message, array $details) : DomainException
+    public static function create(string $message, array $details) : self
     {
         $e = new self($message)
         $e->status = 417;

--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -7,9 +7,14 @@ details response.
 ## ProblemDetailsResponseFactory
 
 This library provides a factory named `Zend\ProblemDetails\ProblemDetailsResponseFactory`.
-It defines two static methods, `createResponse()` and `createResponseFromThrowable()`.
-Each accepts the PSR-7 `ServerRequestInterface` instance as its first argument,
-and then additional arguments in order to create the response itself:
+
+The factory has one _required_ argument: a _response factory_ capable of
+producing an mepty PSR-7 `ResponseInterface`. This may be an PHP callable.
+
+The class defines two static methods, `createResponse()` and
+`createResponseFromThrowable()`.  Each accepts a PSR-7
+`ServerRequestInterface` instance as its first argument, and then additional
+arguments in order to create the response itself:
 
 For `createResponse()`, the signature is:
 
@@ -93,15 +98,18 @@ signature:
 use Psr\Http\Message\ResponseInterface;
 
 public function __construct(
-    bool $isDebug = ProblemDetailsResponseFactory::EXCLUDE_THROWABLE_DETAILS,
+    callable $responseFactory,
+    bool $isDebug = self::EXCLUDE_THROWABLE_DETAILS,
     int $jsonFlags = null,
-    ResponseInterface $response = null,
-    callable $bodyFactory = null
+    bool $exceptionDetailsInResponse = false,
+    string $defaultDetailMessage = self::DEFAULT_DETAIL_MESSAGE
 ) {
 ```
 
 where:
 
+- `callable $responseFactory` is a PHP callable that can produce a PSR-7
+  `ResponseInterface`. The factory will be invoked with no arguments.
 - `bool $isDebug` is a flag indicating whether or not the factory should operate
   in debug mode; the default is not to. You may use the class constants
   `INCLUDE_THROWABLE_DETAILS` or `EXCLUDE_THROWABLE_DETAILS` if desired.
@@ -110,14 +118,16 @@ where:
   `json_encode()` when generating JSON problem details. If you pass a `null`
   value, `JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE |
   JSON_PRESERVE_ZERO_FRACTION` will be used.
-- `ResponseInterface $response` is a PSR-7 response instance to use as the base
-  for any generated response.
-- `callable $bodyFactory` is a PHP callable that will return a PSR-7
-  `StreamInterface` instance. Since some stream implementations are mutable (for
-  instance, those backed by a resource), a factory is necessary in order to
-  ensure a new instance is returned. If you provide such a factory, the stream
-  must be writable. The default will return a zend-diactoros `Stream` instance
-  backed by a PHP temp stream in `wb+` mode.
+- `bool $exceptionDetailsInResponse` is a flag indicating whether or not to
+  include exception details (in particular, the message) when creating the
+  problem details response. By default, for non-`ProblemDetailsExceptionInterface`
+  exceptions, we will not display the message unless this flag is toggled to
+  `true`.
+- `string $defaultDetailMessage` is a string value to use when the
+  `$exceptionDetailsInResponse` flag is `false`, and a
+  non-`ProblemDetailsExceptionInterface` exception is encountered. By default,
+  this is set to the constant `ProblemDetailsResponseFactory::DEFAULT_DETAIL_MESSAGE`,
+  which evaluates to 'An unknown error occurred.'
 
 ## ProblemDetailsResponseFactoryFactory
 
@@ -125,19 +135,17 @@ This package also provides a factory for generating the
 `ProblemDetailsResponseFactory` for usage within dependency injection containers:
 `Zend\ProblemDetails\ProblemDetailsResponseFactoryFactory`. It does the following:
 
+- Pulls the `Psr\Http\Message\ResponseInterface` service to provide as the
+  `$responseFactory` parameter.
 - If a `config` service is present:
     - If the service contains a `debug` key with a boolean value, that value is
       provided as the `$isDebug` parameter.
     - If the service contains a `problem-details` key with an array value
       containing a `json_flags` key, and that value is an integer, that value is
       provided as the `$jsonFlags` parameter.
-- If a `Psr\Http\Message\ResponseInterface` service is present, that service
-  will be provided as the `$response` parameter.
-- If a `ProblemDetails\StreamFactory` service is present, that service will be
-  provided as the `$bodyFactory` parameter.
 
-If any of the above are not present, a `null` value will be passed, allowing the
-default value to be used.
+If any of the above config values are not present, a `null` value will be
+passed, allowing the default value to be used.
 
 If you are using [Expressive](https://docs.zendframework.com/zend-expressive/)
 and have installed [zend-component-installer](https://docs.zendframework.com/zend-component-installer)
@@ -145,12 +153,19 @@ in your application, the above factory will be wired already to the
 `Zend\ProblemDetails\ProblemDetailsResponseFactory` service via the provided
 `Zend\ProblemDetails\ConfigProvider` class.
 
+> ### Response Factory
+>
+> You will need to provide a `Psr\Http\Message\ResponseInterface` service that
+> resolves to a PHP callable capable of returning an instance of that type.
+>
+> If you are using Expressive 3.0.0alpha8 or later, this service is provided via
+> the zend-expressive package itself.
+
 ## Examples
 
 ### Returning a Problem Details response
 
-Let's say you have middleware that you know will only be used in a production
-context, and need to return problem details:
+Let's say you have middleware that needs to return problem details:
 
 ```php
 use Psr\Http\Message\ResponseInterface;
@@ -161,10 +176,17 @@ use Zend\ProblemDetails\ProblemDetailsResponseFactory;
 
 class ApiMiddleware implements MiddlewareInterface
 {
+    private $problemDetailsFactory;
+
+    public function __construct(ProblemDetailsResponseFactory $problemDetailsFactory)
+    {
+        $this->problemDetailsFactory = $problemDetailsFactory;
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // discovered an error, so returning problem details:
-        return (new ProblemDetailsResponseFactory())->createResponse(
+        return $this->problemDetailsFactory->createResponse(
             $request,
             403,
             'You do not have valid credentials to access ' . $request->getUri()->getPath(),
@@ -196,49 +218,10 @@ use Zend\ProblemDetails\ProblemDetailsResponseFactory;
 
 class ApiMiddleware implements MiddlewareInterface
 {
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
-    {
-        try {
-            // some code that may raise an exception or throwable
-        } catch (Throwable $e) {
-            return (new ProblemDetailsResponseFactory())
-                ->createResponseFromThrowable($request, $e);
-        }
-    }
-}
-```
-
-As with the previous example, the above will return a JSON response if the
-`Accept` request header matches `application/json` or any `application/*+json`
-mediatype. Any other mediatype will generate an XML response.
-
-By default, `createResponseFromThrowable()` will only use the exception message, and
-potentially the exception code (if it falls in the 400 or 500 range). If you
-want to include full exception details &mdash; line, file, backtrace, previous
-exceptions &mdash; you must pass a boolean `true` as the first argument to the
-constructor. In most cases, you should only do this in your development or testing
-environment; as such, you would need to provide a flag to your middleware to use
-when invoking the `createResponseFromThrowable()` method, or, more correctly,
-pass a configured `ProblemDetailsResponseFactory` instance to your middleware's
-constructor. As a more complete example:
-
-```php
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
-use Throwable;
-use Zend\ProblemDetails\ProblemDetailsResponseFactory;
-
-class ApiMiddleware implements MiddlewareInterface
-{
     private $problemDetailsFactory;
 
-    public function __construct(
-        /* other arguments*/
-        ProblemDetailsResponseFactory $problemDetailsFactory)
+    public function __construct(ProblemDetailsResponseFactory $problemDetailsFactory)
     {
-        // ...
         $this->problemDetailsFactory = $problemDetailsFactory;
     }
 
@@ -253,6 +236,18 @@ class ApiMiddleware implements MiddlewareInterface
     }
 }
 ```
+
+As with the previous example, the above will return a JSON response if the
+`Accept` request header matches `application/json` or any `application/*+json`
+mediatype. Any other mediatype will generate an XML response.
+
+By default, `createResponseFromThrowable()` will only use the exception message, and
+potentially the exception code (if it falls in the 400 or 500 range). If you
+want to include full exception details &mdash; line, file, backtrace, previous
+exceptions &mdash; you must pass a boolean `true` as the second argument to the
+constructor. In most cases, you should only do this in your development or testing
+environment; as such, you would need to provide a configuration flag for the
+`ProblemDetailsResponseFactoryFactory` to use.
 
 ### Creating Custom Response Types
 

--- a/src/ProblemDetailsMiddleware.php
+++ b/src/ProblemDetailsMiddleware.php
@@ -33,9 +33,9 @@ class ProblemDetailsMiddleware implements MiddlewareInterface
      */
     private $responseFactory;
 
-    public function __construct(ProblemDetailsResponseFactory $responseFactory = null)
+    public function __construct(ProblemDetailsResponseFactory $responseFactory)
     {
-        $this->responseFactory = $responseFactory ?: new ProblemDetailsResponseFactory();
+        $this->responseFactory = $responseFactory;
     }
 
     /**

--- a/src/ProblemDetailsMiddlewareFactory.php
+++ b/src/ProblemDetailsMiddlewareFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
  */
 
@@ -15,8 +15,6 @@ class ProblemDetailsMiddlewareFactory
 {
     public function __invoke(ContainerInterface $container) : ProblemDetailsMiddleware
     {
-        return $container->has(ProblemDetailsResponseFactory::class)
-            ? new ProblemDetailsMiddleware($container->get(ProblemDetailsResponseFactory::class))
-            : new ProblemDetailsMiddleware();
+        return new ProblemDetailsMiddleware($container->get(ProblemDetailsResponseFactory::class));
     }
 }

--- a/src/ProblemDetailsNotFoundHandler.php
+++ b/src/ProblemDetailsNotFoundHandler.php
@@ -23,12 +23,12 @@ class ProblemDetailsNotFoundHandler implements MiddlewareInterface
     private $responseFactory;
 
     /**
-     * @param null|ProblemDetailsResponseFactory $responseFactory Factory to create a response to
+     * @param ProblemDetailsResponseFactory $responseFactory Factory to create a response to
      *     update and return when returning an 404 response.
      */
-    public function __construct(ProblemDetailsResponseFactory $responseFactory = null)
+    public function __construct(ProblemDetailsResponseFactory $responseFactory)
     {
-        $this->responseFactory = $responseFactory ?: new ProblemDetailsResponseFactory();
+        $this->responseFactory = $responseFactory;
     }
 
     /**

--- a/src/ProblemDetailsNotFoundHandlerFactory.php
+++ b/src/ProblemDetailsNotFoundHandlerFactory.php
@@ -15,8 +15,6 @@ class ProblemDetailsNotFoundHandlerFactory
 {
     public function __invoke(ContainerInterface $container) : ProblemDetailsNotFoundHandler
     {
-        return $container->has(ProblemDetailsResponseFactory::class)
-            ? new ProblemDetailsNotFoundHandler($container->get(ProblemDetailsResponseFactory::class))
-            : new ProblemDetailsNotFoundHandler();
+        return new ProblemDetailsNotFoundHandler($container->get(ProblemDetailsResponseFactory::class));
     }
 }

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -197,7 +197,7 @@ class ProblemDetailsResponseFactory
     public function __construct(
         bool $isDebug = self::EXCLUDE_THROWABLE_DETAILS,
         int $jsonFlags = null,
-        ResponseInterface $response = null,
+        callable $responseFactory = null,
         callable $bodyFactory = null,
         bool $exceptionDetailsInResponse = false,
         string $defaultDetailMessage = self::DEFAULT_DETAIL_MESSAGE
@@ -205,7 +205,11 @@ class ProblemDetailsResponseFactory
         $this->isDebug = $isDebug;
         $this->jsonFlags = $jsonFlags
             ?: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
-        $this->response = $response ?: new Response();
+        if ($responseFactory !== null) {
+            $this->response = $responseFactory();
+        } else {
+            $this->response = new Response();
+        }
         $this->bodyFactory = $bodyFactory ?: Closure::fromCallable([$this, 'generateStream']);
         $this->exceptionDetailsInResponse = $exceptionDetailsInResponse;
         $this->defaultDetailMessage = $defaultDetailMessage;

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
  */
 
@@ -17,8 +17,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Spatie\ArrayToXml\ArrayToXml;
 use Throwable;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\Stream;
 
 /**
  * Create a Problem Details response.
@@ -135,18 +133,6 @@ class ProblemDetailsResponseFactory
     ];
 
     /**
-     * Factory for generating an empty response body.
-     *
-     * If none is provided, defaults to a closure that returns an empty
-     * zend-diactoros Stream instance using a php://temp stream.
-     *
-     * The factory MUST return a StreamInterface
-     *
-     * @var callable
-     */
-    private $bodyFactory;
-
-    /**
      * Whether or not to include debug details.
      *
      * Debug details are only included for responses created from throwables,
@@ -167,13 +153,12 @@ class ProblemDetailsResponseFactory
     private $jsonFlags;
 
     /**
-     * Response prototype to use when generating Problem Details responses.
+     * Factory to use to generate prototype response used when generating a
+     * problem details response.
      *
-     * Defaults to a zend-diactoros response if none is injected.
-     *
-     * @var ResponseInterface
+     * @var callable
      */
-    private $response;
+    private $responseFactory;
 
     /**
      * Flag to enable show exception details in detail field.
@@ -195,22 +180,19 @@ class ProblemDetailsResponseFactory
     private $defaultDetailMessage;
 
     public function __construct(
+        callable $responseFactory,
         bool $isDebug = self::EXCLUDE_THROWABLE_DETAILS,
         int $jsonFlags = null,
-        callable $responseFactory = null,
-        callable $bodyFactory = null,
         bool $exceptionDetailsInResponse = false,
         string $defaultDetailMessage = self::DEFAULT_DETAIL_MESSAGE
     ) {
+        // Ensures type safety of the composed factory
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
         $this->isDebug = $isDebug;
         $this->jsonFlags = $jsonFlags
             ?: JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
-        if ($responseFactory !== null) {
-            $this->response = $responseFactory();
-        } else {
-            $this->response = new Response();
-        }
-        $this->bodyFactory = $bodyFactory ?: Closure::fromCallable([$this, 'generateStream']);
         $this->exceptionDetailsInResponse = $exceptionDetailsInResponse;
         $this->defaultDetailMessage = $defaultDetailMessage;
     }
@@ -340,30 +322,14 @@ class ProblemDetailsResponseFactory
         );
     }
 
-    /**
-     * @throws Exception\InvalidResponseBodyException
-     */
     protected function generateResponse(int $status, string $contentType, string $payload) : ResponseInterface
     {
-        $body = ($this->bodyFactory)();
-        if (! $body instanceof StreamInterface) {
-            throw new Exception\InvalidResponseBodyException(sprintf(
-                'The factory for generating a problem details response body stream did not return a %s',
-                StreamInterface::class
-            ));
-        }
+        $response = ($this->responseFactory)();
+        $response->getBody()->write($payload);
 
-        $body->write($payload);
-
-        return $this->response
+        return $response
             ->withStatus($status)
-            ->withHeader('Content-Type', $contentType)
-            ->withBody($body);
-    }
-
-    private function generateStream() : StreamInterface
-    {
-        return new Stream('php://temp', 'wb+');
+            ->withHeader('Content-Type', $contentType);
     }
 
     private function getResponseGenerator(ServerRequestInterface $request) : callable

--- a/src/ProblemDetailsResponseFactoryFactory.php
+++ b/src/ProblemDetailsResponseFactoryFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
  */
 
@@ -22,19 +22,10 @@ class ProblemDetailsResponseFactoryFactory
         $problemDetailsConfig = $config['problem-details'] ?? [];
         $jsonFlags = $problemDetailsConfig['json_flags'] ?? null;
 
-        $responsePrototype = $container->has(ResponseInterface::class)
-            ? $container->get(ResponseInterface::class)
-            : null;
-
-        $streamFactory = $container->has('Zend\ProblemDetails\StreamFactory')
-            ? $container->get('Zend\ProblemDetails\StreamFactory')
-            : null;
-
         return new ProblemDetailsResponseFactory(
+            $container->get(ResponseInterface::class),
             $includeThrowableDetail,
             $jsonFlags,
-            $responsePrototype,
-            $streamFactory,
             $includeThrowableDetail
         );
     }

--- a/test/ProblemDetailsAssertionsTrait.php
+++ b/test/ProblemDetailsAssertionsTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
  */
 
@@ -9,7 +9,11 @@ declare(strict_types=1);
 
 namespace ZendTest\ProblemDetails;
 
+use PHPUnit\Framework\Assert;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Throwable;
 
 trait ProblemDetailsAssertionsTrait
@@ -52,30 +56,58 @@ trait ProblemDetailsAssertionsTrait
         $this->assertInternalType('array', $details['trace']);
     }
 
-    public function getPayloadFromResponse(ResponseInterface $response) : array
-    {
-        $contentType = $response->getHeaderLine('Content-Type');
-
+    /**
+     * @param StreamInterface|ObjectProphecy $stream
+     */
+    public function prepareResponsePayloadAssertions(
+        string $contentType,
+        ObjectProphecy $stream,
+        callable $assertion
+    ) : void {
         if ('application/problem+json' === $contentType) {
-            return $this->getPayloadFromJsonResponse($response);
+            $this->preparePayloadForJsonResponse($stream, $assertion);
+            return;
         }
 
         if ('application/problem+xml' === $contentType) {
-            return $this->getPayloadFromXmlResponse($response);
+            $this->preparePayloadForXmlResponse($stream, $assertion);
+            return;
         }
     }
 
-    public function getPayloadFromJsonResponse(ResponseInterface $response) : array
+    /**
+     * @param StreamInterface|ObjectProphecy $stream
+     */
+    public function preparePayloadForJsonResponse(ObjectProphecy $stream, callable $assertion) : void
     {
-        $body = $response->getBody();
-        $json = (string) $body;
-        return json_decode($json, true);
+        $stream
+            ->write(Argument::that(function ($body) use ($assertion) {
+                Assert::assertInternalType('string', $body);
+                $data = json_decode($body, true);
+                $assertion($data);
+                return $body;
+            }))
+            ->shouldBeCalled();
     }
 
-    public function getPayloadFromXmlResponse(ResponseInterface $response) : array
+    /**
+     * @param StreamInterface|ObjectProphecy $stream
+     */
+    public function preparePayloadForXmlResponse(ObjectProphecy $stream, callable $assertion) : void
     {
-        $body = $response->getBody();
-        $xml = simplexml_load_string((string) $body);
+        $stream
+            ->write(Argument::that(function ($body) use ($assertion) {
+                Assert::assertInternalType('string', $body);
+                $data = $this->deserializeXmlPayload($body);
+                $assertion($data);
+                return $body;
+            }))
+            ->shouldBeCalled();
+    }
+
+    public function deserializeXmlPayload(string $xml) : array
+    {
+        $xml = simplexml_load_string($xml);
         $json = json_encode($xml);
         $payload = json_decode($json, true);
 

--- a/test/ProblemDetailsMiddlewareTest.php
+++ b/test/ProblemDetailsMiddlewareTest.php
@@ -50,8 +50,7 @@ class ProblemDetailsMiddlewareTest extends TestCase
             ->will([$response, 'reveal']);
 
 
-        $middleware = new ProblemDetailsMiddleware();
-        $result = $middleware->process($this->request->reveal(), $handler->reveal());
+        $result = $this->middleware->process($this->request->reveal(), $handler->reveal());
 
         $this->assertSame($response->reveal(), $result);
     }
@@ -118,12 +117,10 @@ class ProblemDetailsMiddlewareTest extends TestCase
             ->handle(Argument::that([$this->request, 'reveal']))
             ->willThrow($exception);
 
-        $middleware = new ProblemDetailsMiddleware();
-
         $this->expectException(TestAsset\RuntimeException::class);
         $this->expectExceptionMessage('Thrown!');
         $this->expectExceptionCode(507);
-        $middleware->process($this->request->reveal(), $handler->reveal());
+        $this->middleware->process($this->request->reveal(), $handler->reveal());
     }
 
     /**

--- a/test/ProblemDetailsNotFoundHandlerFactoryTest.php
+++ b/test/ProblemDetailsNotFoundHandlerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-problem-details for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-problem-details/blob/master/LICENSE.md New BSD License
  */
 
@@ -11,6 +11,7 @@ namespace ZendTest\ProblemDetails;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 use Zend\ProblemDetails\ProblemDetailsNotFoundHandler;
 use Zend\ProblemDetails\ProblemDetailsNotFoundHandlerFactory;
 use Zend\ProblemDetails\ProblemDetailsResponseFactory;
@@ -23,25 +24,18 @@ class ProblemDetailsNotFoundHandlerFactoryTest extends TestCase
         $this->factory = new ProblemDetailsNotFoundHandlerFactory();
     }
 
-    public function testCreatesNotFoundHandlerWithoutResponseFactoryIfServiceDoesNotExist() : void
+    public function testRaisesExceptionWhenProblemDetailsResponseFactoryServiceIsNotAvailable()
     {
-        $this->container->has(ProblemDetailsResponseFactory::class)->willReturn(false);
-        $this->container->get(ProblemDetailsResponseFactory::class)->shouldNotBeCalled();
+        $e = new RuntimeException();
+        $this->container->get(ProblemDetailsResponseFactory::class)->willThrow($e);
 
-        $notFoundHandler = ($this->factory)($this->container->reveal());
-
-        $this->assertInstanceOf(ProblemDetailsNotFoundHandler::class, $notFoundHandler);
-        $this->assertAttributeInstanceOf(
-            ProblemDetailsResponseFactory::class,
-            'responseFactory',
-            $notFoundHandler
-        );
+        $this->expectException(RuntimeException::class);
+        $this->factory->__invoke($this->container->reveal());
     }
 
     public function testCreatesNotFoundHandlerUsingResponseFactoryService() : void
     {
         $responseFactory = $this->prophesize(ProblemDetailsResponseFactory::class)->reveal();
-        $this->container->has(ProblemDetailsResponseFactory::class)->willReturn(true);
         $this->container->get(ProblemDetailsResponseFactory::class)->willReturn($responseFactory);
 
         $notFoundHandler = ($this->factory)($this->container->reveal());

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -10,10 +10,14 @@ declare(strict_types=1);
 namespace ZendTest\ProblemDetails;
 
 use Closure;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Zend\Diactoros\Response;
+use ReflectionProperty;
+use RuntimeException;
+use stdClass;
+use TypeError;
 use Zend\ProblemDetails\ProblemDetailsResponseFactory;
 use Zend\ProblemDetails\ProblemDetailsResponseFactoryFactory;
 
@@ -24,11 +28,48 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
     }
 
-    public function testLackOfOptionalServicesResultsInFactoryUsingDefaults() : void
+    public function assertResponseFactoryReturns(ResponseInterface $expected, ProblemDetailsResponseFactory $factory)
+    {
+        $r = new ReflectionProperty($factory, 'responseFactory');
+        $r->setAccessible(true);
+        $responseFactory = $r->getValue($factory);
+
+        Assert::assertSame($expected, $responseFactory());
+    }
+
+    public function testLackOfResponseServiceResultsInException()
+    {
+        $factory = new ProblemDetailsResponseFactoryFactory();
+        $e = new RuntimeException();
+
+        $this->container->has('config')->willReturn(false);
+        $this->container->get('config')->shouldNotBeCalled();
+        $this->container->get(ResponseInterface::class)->willThrow($e);
+
+        $this->expectException(RuntimeException::class);
+        $factory($this->container->reveal());
+    }
+
+    public function testNonCallableResponseServiceResultsInException()
+    {
+        $factory = new ProblemDetailsResponseFactoryFactory();
+
+        $this->container->has('config')->willReturn(false);
+        $this->container->get('config')->shouldNotBeCalled();
+        $this->container->get(ResponseInterface::class)->willReturn(new stdClass);
+
+        $this->expectException(TypeError::class);
+        $factory($this->container->reveal());
+    }
+
+    public function testLackOfConfigServiceResultsInFactoryUsingDefaults() : void
     {
         $this->container->has('config')->willReturn(false);
-        $this->container->has(ResponseInterface::class)->willReturn(false);
-        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $this->container->get(ResponseInterface::class)->willReturn(function () use ($response) {
+            return $response;
+        });
 
         $factoryFactory = new ProblemDetailsResponseFactoryFactory();
         $factory = $factoryFactory($this->container->reveal());
@@ -41,8 +82,8 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
             $factory
         );
 
-        $this->assertAttributeInstanceOf(Response::class, 'response', $factory);
-        $this->assertAttributeInstanceOf(Closure::class, 'bodyFactory', $factory);
+        $this->assertAttributeInstanceOf(Closure::class, 'responseFactory', $factory);
+        $this->assertResponseFactoryReturns($response, $factory);
     }
 
     public function testUsesDebugSettingFromConfigWhenPresent() : void
@@ -50,8 +91,8 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(['debug' => true]);
 
-        $this->container->has(ResponseInterface::class)->willReturn(false);
-        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
+        $this->container->get(ResponseInterface::class)->willReturn(function () {
+        });
 
         $factoryFactory = new ProblemDetailsResponseFactoryFactory();
         $factory = $factoryFactory($this->container->reveal());
@@ -66,49 +107,13 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->container->has('config')->willReturn(true);
         $this->container->get('config')->willReturn(['problem-details' => ['json_flags' => JSON_PRETTY_PRINT]]);
 
-        $this->container->has(ResponseInterface::class)->willReturn(false);
-        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
+        $this->container->get(ResponseInterface::class)->willReturn(function () {
+        });
 
         $factoryFactory = new ProblemDetailsResponseFactoryFactory();
         $factory = $factoryFactory($this->container->reveal());
 
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
         $this->assertAttributeSame(JSON_PRETTY_PRINT, 'jsonFlags', $factory);
-    }
-
-    public function testUsesResponseServiceFromContainerWhenPresent() : void
-    {
-        $responseFactory = function () : Response {
-            return new Response();
-        };
-
-        $this->container->has('config')->willReturn(false);
-        $this->container->has(ResponseInterface::class)->willReturn(true);
-        $this->container->get(ResponseInterface::class)->willReturn($responseFactory);
-        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
-
-        $factoryFactory = new ProblemDetailsResponseFactoryFactory();
-        $factory = $factoryFactory($this->container->reveal());
-
-        $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
-        $this->assertAttributeInstanceOf(Response::class, 'response', $factory);
-    }
-
-    public function testUsesStreamFactoryServiceFromContainerWhenPresent() : void
-    {
-        // @codingStandardsIgnoreStart
-        $streamFactory = function () { };
-        // @codingStandardsIgnoreEnd
-
-        $this->container->has('config')->willReturn(false);
-        $this->container->has(ResponseInterface::class)->willReturn(false);
-        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(true);
-        $this->container->get('Zend\ProblemDetails\StreamFactory')->willReturn($streamFactory);
-
-        $factoryFactory = new ProblemDetailsResponseFactoryFactory();
-        $factory = $factoryFactory($this->container->reveal());
-
-        $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
-        $this->assertAttributeSame($streamFactory, 'bodyFactory', $factory);
     }
 }

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -78,18 +78,20 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
 
     public function testUsesResponseServiceFromContainerWhenPresent() : void
     {
-        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $responseFactory = function () : Response {
+            return new Response();
+        };
 
         $this->container->has('config')->willReturn(false);
         $this->container->has(ResponseInterface::class)->willReturn(true);
-        $this->container->get(ResponseInterface::class)->willReturn($response);
+        $this->container->get(ResponseInterface::class)->willReturn($responseFactory);
         $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
 
         $factoryFactory = new ProblemDetailsResponseFactoryFactory();
         $factory = $factoryFactory($this->container->reveal());
 
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
-        $this->assertAttributeSame($response, 'response', $factory);
+        $this->assertAttributeInstanceOf(Response::class, 'response', $factory);
     }
 
     public function testUsesStreamFactoryServiceFromContainerWhenPresent() : void


### PR DESCRIPTION
This patch builds on #33 and ultimately supercedes it.

Instead of composing a response prototype and a stream factory, it now composes a response _factory_, which **MUST** be supplied during instantiation.

This has other implications: the various classes that use a `ProblemDetailsResponseFactory` now can no longer create them without arguments. As such, such constructor arguments are no longer optional, but required.

The side benefit is that this completely de-couples the library from Diactoros!

Fixes #32.