### PR TITLE
Allow ResponseInterface service to return a factory instead of instance

### DIFF
--- a/src/ProblemDetailsResponseFactoryFactory.php
+++ b/src/ProblemDetailsResponseFactoryFactory.php
@@ -20,9 +20,7 @@ class ProblemDetailsResponseFactoryFactory
         $problemDetailsConfig = $config['problem-details'] ?? [];
         $jsonFlags = $problemDetailsConfig['json_flags'] ?? null;
 
-        $responsePrototype = $container->has(ResponseInterface::class)
-            ? $container->get(ResponseInterface::class)
-            : null;
+        $responsePrototype = $this->getResponsePrototype($container);
 
         $streamFactory = $container->has('Zend\ProblemDetails\StreamFactory')
             ? $container->get('Zend\ProblemDetails\StreamFactory')
@@ -35,5 +33,18 @@ class ProblemDetailsResponseFactoryFactory
             $streamFactory,
             $includeThrowableDetail
         );
+    }
+
+    /**
+     * @return null|ResponseInterface
+     */
+    private function getResponsePrototype(ContainerInterface $container)
+    {
+        if (! $container->has(ResponseInterface::class)) {
+            return null;
+        }
+
+        $response = $container->get(ResponseInterface::class);
+        return is_callable($response) ? $response() : $response;
     }
 }

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -90,6 +90,25 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->assertAttributeSame($response, 'response', $factory);
     }
 
+    public function testUsesResponseServiceAsFactoryFromContainerWhenPresent() : void
+    {
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+        $responseFactory = function () use ($response) {
+            return $response;
+        };
+
+        $this->container->has('config')->willReturn(false);
+        $this->container->has(ResponseInterface::class)->willReturn(true);
+        $this->container->get(ResponseInterface::class)->willReturn($responseFactory);
+        $this->container->has('Zend\ProblemDetails\StreamFactory')->willReturn(false);
+
+        $factoryFactory = new ProblemDetailsResponseFactoryFactory();
+        $factory = $factoryFactory($this->container->reveal());
+
+        $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
+        $this->assertAttributeSame($response, 'response', $factory);
+    }
+
     public function testUsesStreamFactoryServiceFromContainerWhenPresent() : void
     {
         // @codingStandardsIgnoreStart


### PR DESCRIPTION
Per the Expressive 2.2 release, allowing the ResponseInterface service to allow returning a factory instead of an instance.