### PR TITLE
fix crash when api-problem tries to encode malformed UTF-8 to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Versions 0.3.0 and prior were released as "weierophinney/problem-details".
 
 - [#39](https://github.com/zendframework/zend-problem-details/pull/39)
   adds the `public` visibility modifier to all constants.
+- [#41](https://github.com/zendframework/zend-problem-details/pull/41)
+  prevent crashing when ApiProblem tried to encode malformed UTF-8 sequences to JSON
 
 ## 1.0.0 - 2018-03-15
 

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Spatie\ArrayToXml\ArrayToXml;
 use Throwable;
+
 use function array_merge;
 use function array_walk_recursive;
 use function get_class;
@@ -29,11 +30,12 @@ use function preg_replace;
 use function print_r;
 use function sprintf;
 use function strpos;
+
+use const JSON_PARTIAL_OUTPUT_ON_ERROR;
 use const JSON_PRESERVE_ZERO_FRACTION;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
-use const JSON_PARTIAL_OUTPUT_ON_ERROR;
 
 /**
  * Create a Problem Details response.
@@ -215,7 +217,9 @@ class ProblemDetailsResponseFactory
         };
         $this->isDebug = $isDebug;
         if (! $jsonFlags) {
-            $jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+            $jsonFlags = JSON_UNESCAPED_SLASHES
+                | JSON_UNESCAPED_UNICODE
+                | JSON_PRESERVE_ZERO_FRACTION
                 | JSON_PARTIAL_OUTPUT_ON_ERROR;
             if ($isDebug) {
                 $jsonFlags = JSON_PRETTY_PRINT | $jsonFlags;

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -16,7 +16,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Spatie\ArrayToXml\ArrayToXml;
 use Throwable;
-
 use function array_merge;
 use function array_walk_recursive;
 use function get_class;
@@ -30,11 +29,11 @@ use function preg_replace;
 use function print_r;
 use function sprintf;
 use function strpos;
-
 use const JSON_PRESERVE_ZERO_FRACTION;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
+use const JSON_PARTIAL_OUTPUT_ON_ERROR;
 
 /**
  * Create a Problem Details response.
@@ -166,8 +165,11 @@ class ProblemDetailsResponseFactory
      *
      * On non-debug mode:
      * defaults to JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+     * | JSON_PARTIAL_OUTPUT_ON_ERROR
+     *
      * On debug mode:
      * defaults to JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+     * | JSON_PARTIAL_OUTPUT_ON_ERROR
      *
      * @var int
      */
@@ -213,7 +215,8 @@ class ProblemDetailsResponseFactory
         };
         $this->isDebug = $isDebug;
         if (! $jsonFlags) {
-            $jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION;
+            $jsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+                | JSON_PARTIAL_OUTPUT_ON_ERROR;
             if ($isDebug) {
                 $jsonFlags = JSON_PRETTY_PRINT | $jsonFlags;
             }

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -104,12 +104,7 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $factoryFactory = new ProblemDetailsResponseFactoryFactory();
         $factory = $factoryFactory($this->container->reveal());
 
-        $this->assertAttributeSame(
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
-            | JSON_PARTIAL_OUTPUT_ON_ERROR,
-            'jsonFlags',
-            $factory
-        );
+        $this->assertSame(JSON_PRETTY_PRINT, Assert::readAttribute($factory, 'jsonFlags') & JSON_PRETTY_PRINT);
     }
 
     public function testUsesDebugSettingFromConfigWhenPresent() : void

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -82,7 +82,9 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
         $this->assertAttributeSame(ProblemDetailsResponseFactory::EXCLUDE_THROWABLE_DETAILS, 'isDebug', $factory);
         $this->assertAttributeSame(
-            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+            JSON_UNESCAPED_SLASHES
+            | JSON_UNESCAPED_UNICODE
+            | JSON_PRESERVE_ZERO_FRACTION
             | JSON_PARTIAL_OUTPUT_ON_ERROR,
             'jsonFlags',
             $factory

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -82,7 +82,8 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
         $this->assertAttributeSame(ProblemDetailsResponseFactory::EXCLUDE_THROWABLE_DETAILS, 'isDebug', $factory);
         $this->assertAttributeSame(
-            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+            | JSON_PARTIAL_OUTPUT_ON_ERROR,
             'jsonFlags',
             $factory
         );
@@ -104,7 +105,8 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $factory = $factoryFactory($this->container->reveal());
 
         $this->assertAttributeSame(
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION
+            | JSON_PARTIAL_OUTPUT_ON_ERROR,
             'jsonFlags',
             $factory
         );

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -444,7 +444,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $e->getType()->willReturn('https://example.com/api/doc/invalid-client-request');
         $e->getAdditionalData()->willReturn([
             'malformed-utf8' => self::UTF_8_INVALID_2_OCTET_SEQUENCE,
-            ]);
+        ]);
 
         $this->request->getHeaderLine('Accept')->willReturn('application/json');
 


### PR DESCRIPTION
This fixes #40.

Instead of throwing a `TypeError`, the malformed UTF-8 is now omitted.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.
