### PR TITLE
TestCase - bug in XML encoding line returns chr(10).

### DIFF
--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -318,7 +318,7 @@ class ProblemDetailsResponseFactory
     {
         $return = [];
         foreach ($input as $key => $value) {
-            $key = str_replace(chr(10), '_', $key);
+            $key = str_replace("\n", '_', $key);
             $startCharacterPattern =
                 '[A-Z]|_|[a-z]|[\xC0-\xD6]|[\xD8-\xF6]|[\xF8-\x{2FF}]|[\x{370}-\x{37D}]|[\x{37F}-\x{1FFF}]|'
                 . '[\x{200C}-\x{200D}]|[\x{2070}-\x{218F}]|[\x{2C00}-\x{2FEF}]|[\x{3001}-\x{D7FF}]|[\x{F900}-\x{FDCF}]'

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -318,6 +318,7 @@ class ProblemDetailsResponseFactory
     {
         $return = [];
         foreach ($input as $key => $value) {
+            $key = str_replace(chr(10), '_', $key);
             $startCharacterPattern =
                 '[A-Z]|_|[a-z]|[\xC0-\xD6]|[\xD8-\xF6]|[\xF8-\x{2FF}]|[\x{370}-\x{37D}]|[\x{37F}-\x{1FFF}]|'
                 . '[\x{200C}-\x{200D}]|[\x{2070}-\x{218F}]|[\x{2C00}-\x{2FEF}]|[\x{3001}-\x{D7FF}]|[\x{F900}-\x{FDCF}]'

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -153,8 +153,8 @@ class ProblemDetailsResponseFactoryTest extends TestCase
                 'A#-' => 'foo',
                 '-A-' => 'foo',
                 '#B-' => 'foo',
-                "A\n-" => 'foo',
-                chr(10).'A-' => 'foo',
+                "C\n-" => 'foo',
+                chr(10).'C-' => 'foo',
             ],
         ];
 
@@ -163,8 +163,8 @@ class ProblemDetailsResponseFactoryTest extends TestCase
                 'A_-',
                 '_A-',
                 '_B-',
-                'A_-',
-                '_A-',
+                'C_-',
+                '_C-',
             ];
         } else {
             $expectedKeyNames = array_keys($additional['foo']);

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -153,6 +153,8 @@ class ProblemDetailsResponseFactoryTest extends TestCase
                 'A#-' => 'foo',
                 '-A-' => 'foo',
                 '#B-' => 'foo',
+                "A\n-" => 'foo',
+                chr(10).'A-' => 'foo',
             ],
         ];
 
@@ -161,6 +163,8 @@ class ProblemDetailsResponseFactoryTest extends TestCase
                 'A_-',
                 '_A-',
                 '_B-',
+                'A_-',
+                '_A-',
             ];
         } else {
             $expectedKeyNames = array_keys($additional['foo']);


### PR DESCRIPTION
This patch provides tests demonstrating that invalid whitespace characters are not stripped when creating XML tag names.

Related: #45