### PR TITLE
Feature/default types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Versions 0.3.0 and prior were released as "weierophinney/problem-details".
 
 ### Added
 
-- Nothing.
+- [#51](https://github.com/zendframework/zend-problem-details/pull/51) adds new `problem-details.default_types_map`
+  config option, that can be used to define custom `type` values based on status codes.
 
 ### Changed
 

--- a/docs/book/default-types.md
+++ b/docs/book/default-types.md
@@ -1,0 +1,46 @@
+# Default types
+
+When you raise your own exceptions implementing `Zend\ProblemDetails\Exception\ProblemDetailsExceptionInterface` you
+will always be in control of all the properties returned as part of the response payload, naming `status`, `type`,
+`title`, `detail`, etc.
+
+However, there are some use cases in which this library will have to infer some of those values.
+
+The main situations in which this can happen are:
+
+* When an exception not implementing `ProblemDetailsExceptionInterface` is captured by the `ProblemDetailsMiddleware`.
+* When the `ProblemDetailsNotFoundHandler` is executed.
+
+In these two cases, the `title` and `type` properties will be inferred from the status code, which will usually be
+`500` in the first case and `404` in the second one.
+
+> To be more precise, the `ProblemDetailsMiddleware` will use the exception's error code when `debug` is `true`,
+> and `500` otherwise.
+
+Because of this, in any of those cases, you will end up with values like `https://httpstatus.es/404` or
+`https://httpstatus.es/500` for the `type` property.
+
+## Configuring custom default types
+
+Since the `type` property will usually be used by API consumers to uniquely identify an error, you might want to be
+able to provide your own custom values for the `type` property.
+
+In order to do that, this library lets you configure the default `type` value to be used for every status code
+when some of the cases listed above happens.
+
+```php
+return [
+
+    'problem-details' => [
+        'default_types_map' => [
+            404 => 'https://example.com/problem-details/error/not-found',
+            500 => 'https://example.com/problem-details/error/internal-server-error',
+        ],
+    ],
+
+];
+```
+
+If this configuration is found, it will be consumed by the
+[ProblemDetailsResponseFactoryFactory](response.md#problemdetailsresponsefactoryfactory) and your custom values will
+be used when the `type` was not explicitly provided.

--- a/docs/book/response.md
+++ b/docs/book/response.md
@@ -146,6 +146,10 @@ This package also provides a factory for generating the
     - If the service contains a `problem-details` key with an array value
       containing a `json_flags` key, and that value is an integer, that value is
       provided as the `$jsonFlags` parameter.
+    - If the service contains a `problem-details` key with an array value
+      containing a `default_types_map` key, and that value is an array, that value is
+      provided as the `$defaultTypesMap` parameter.
+      > More information about defining [default types](default-types.md).
 
 If any of the above config values are not present, a `null` value will be
 passed, allowing the default value to be used.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
         - "Exceptions": exception.md
         - "Error Handling Middleware": middleware.md
         - "Not Found Handler": not-found-handler.md
+        - "Default types": default-types.md
 site_name: zend-problem-details
 site_description: 'PSR-7 Problem Details for HTTP API responses and middleware'
 repo_url: 'https://github.com/zendframework/zend-problem-details'

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -204,12 +204,22 @@ class ProblemDetailsResponseFactory
      */
     private $defaultDetailMessage;
 
+    /**
+     * A map used to infer the "type" property based on the status code.
+     *
+     * Defaults to an empty map.
+     *
+     * @var array
+     */
+    private $defaultTypes;
+
     public function __construct(
         callable $responseFactory,
         bool $isDebug = self::EXCLUDE_THROWABLE_DETAILS,
         int $jsonFlags = null,
         bool $exceptionDetailsInResponse = false,
-        string $defaultDetailMessage = self::DEFAULT_DETAIL_MESSAGE
+        string $defaultDetailMessage = self::DEFAULT_DETAIL_MESSAGE,
+        array $defaultTypes = []
     ) {
         // Ensures type safety of the composed factory
         $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
@@ -228,6 +238,7 @@ class ProblemDetailsResponseFactory
         $this->jsonFlags = $jsonFlags;
         $this->exceptionDetailsInResponse = $exceptionDetailsInResponse;
         $this->defaultDetailMessage = $defaultDetailMessage;
+        $this->defaultTypes = $defaultTypes;
     }
 
     public function createResponse(
@@ -392,7 +403,7 @@ class ProblemDetailsResponseFactory
 
     private function createTypeFromStatus(int $status) : string
     {
-        return sprintf('https://httpstatus.es/%s', $status);
+        return $this->defaultTypes[$status] ?? sprintf('https://httpstatus.es/%s', $status);
     }
 
     private function createThrowableDetail(Throwable $e) : array

--- a/src/ProblemDetailsResponseFactory.php
+++ b/src/ProblemDetailsResponseFactory.php
@@ -211,7 +211,7 @@ class ProblemDetailsResponseFactory
      *
      * @var array
      */
-    private $defaultTypes;
+    private $defaultTypesMap;
 
     public function __construct(
         callable $responseFactory,
@@ -219,7 +219,7 @@ class ProblemDetailsResponseFactory
         int $jsonFlags = null,
         bool $exceptionDetailsInResponse = false,
         string $defaultDetailMessage = self::DEFAULT_DETAIL_MESSAGE,
-        array $defaultTypes = []
+        array $defaultTypesMap = []
     ) {
         // Ensures type safety of the composed factory
         $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
@@ -238,7 +238,7 @@ class ProblemDetailsResponseFactory
         $this->jsonFlags = $jsonFlags;
         $this->exceptionDetailsInResponse = $exceptionDetailsInResponse;
         $this->defaultDetailMessage = $defaultDetailMessage;
-        $this->defaultTypes = $defaultTypes;
+        $this->defaultTypesMap = $defaultTypesMap;
     }
 
     public function createResponse(
@@ -403,7 +403,7 @@ class ProblemDetailsResponseFactory
 
     private function createTypeFromStatus(int $status) : string
     {
-        return $this->defaultTypes[$status] ?? sprintf('https://httpstatus.es/%s', $status);
+        return $this->defaultTypesMap[$status] ?? sprintf('https://httpstatus.es/%s', $status);
     }
 
     private function createThrowableDetail(Throwable $e) : array

--- a/src/ProblemDetailsResponseFactoryFactory.php
+++ b/src/ProblemDetailsResponseFactoryFactory.php
@@ -21,7 +21,7 @@ class ProblemDetailsResponseFactoryFactory
 
         $problemDetailsConfig = $config['problem-details'] ?? [];
         $jsonFlags = $problemDetailsConfig['json_flags'] ?? null;
-        $defaultTypes = $problemDetailsConfig['default_types'] ?? [];
+        $defaultTypesMap = $problemDetailsConfig['default_types_map'] ?? [];
 
         return new ProblemDetailsResponseFactory(
             $container->get(ResponseInterface::class),
@@ -29,7 +29,7 @@ class ProblemDetailsResponseFactoryFactory
             $jsonFlags,
             $includeThrowableDetail,
             ProblemDetailsResponseFactory::DEFAULT_DETAIL_MESSAGE,
-            $defaultTypes
+            $defaultTypesMap
         );
     }
 }

--- a/src/ProblemDetailsResponseFactoryFactory.php
+++ b/src/ProblemDetailsResponseFactoryFactory.php
@@ -21,12 +21,15 @@ class ProblemDetailsResponseFactoryFactory
 
         $problemDetailsConfig = $config['problem-details'] ?? [];
         $jsonFlags = $problemDetailsConfig['json_flags'] ?? null;
+        $defaultTypes = $problemDetailsConfig['default_types'] ?? [];
 
         return new ProblemDetailsResponseFactory(
             $container->get(ResponseInterface::class),
             $includeThrowableDetail,
             $jsonFlags,
-            $includeThrowableDetail
+            $includeThrowableDetail,
+            ProblemDetailsResponseFactory::DEFAULT_DETAIL_MESSAGE,
+            $defaultTypes
         );
     }
 }

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -147,7 +147,9 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         ];
 
         $this->container->has('config')->willReturn(true);
-        $this->container->get('config')->willReturn(['problem-details' => ['default_types' => $expectedDefaultTypes]]);
+        $this->container->get('config')->willReturn(
+            ['problem-details' => ['default_types_map' => $expectedDefaultTypes]]
+        );
 
         $this->container->get(ResponseInterface::class)->willReturn(function () {
         });
@@ -156,6 +158,6 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $factory = $factoryFactory($this->container->reveal());
 
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
-        $this->assertAttributeSame($expectedDefaultTypes, 'defaultTypes', $factory);
+        $this->assertAttributeSame($expectedDefaultTypes, 'defaultTypesMap', $factory);
     }
 }

--- a/test/ProblemDetailsResponseFactoryFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryFactoryTest.php
@@ -139,4 +139,23 @@ class ProblemDetailsResponseFactoryFactoryTest extends TestCase
         $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
         $this->assertAttributeSame(JSON_PRETTY_PRINT, 'jsonFlags', $factory);
     }
+
+    public function testUsesDefaultTypesSettingFromConfigWhenPresent() : void
+    {
+        $expectedDefaultTypes = [
+            404 => 'https://example.com/problem-details/error/not-found',
+        ];
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn(['problem-details' => ['default_types' => $expectedDefaultTypes]]);
+
+        $this->container->get(ResponseInterface::class)->willReturn(function () {
+        });
+
+        $factoryFactory = new ProblemDetailsResponseFactoryFactory();
+        $factory = $factoryFactory($this->container->reveal());
+
+        $this->assertInstanceOf(ProblemDetailsResponseFactory::class, $factory);
+        $this->assertAttributeSame($expectedDefaultTypes, 'defaultTypes', $factory);
+    }
 }

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -479,15 +479,15 @@ class ProblemDetailsResponseFactoryTest extends TestCase
 
     public function provideMappedStatuses() : array
     {
-        $defaultTypes = [
+        $defaultTypesMap = [
             404 => 'https://example.com/problem-details/error/not-found',
             500 => 'https://example.com/problem-details/error/internal-server-error',
         ];
 
         return [
-            [$defaultTypes, 404, 'https://example.com/problem-details/error/not-found'],
-            [$defaultTypes, 500, 'https://example.com/problem-details/error/internal-server-error'],
-            [$defaultTypes, 400, 'https://httpstatus.es/400'],
+            [$defaultTypesMap, 404, 'https://example.com/problem-details/error/not-found'],
+            [$defaultTypesMap, 500, 'https://example.com/problem-details/error/internal-server-error'],
+            [$defaultTypesMap, 400, 'https://httpstatus.es/400'],
             [[], 500, 'https://httpstatus.es/500'],
         ];
     }
@@ -495,7 +495,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
     /**
      * @dataProvider provideMappedStatuses
      */
-    public function testTypeIsInferredFromDefaultTypesMap(array $defaultTypes, int $status, string $expectedType) : void
+    public function testTypeIsInferredFromDefaultTypesMap(array $map, int $status, string $expectedType) : void
     {
         $this->request->getHeaderLine('Accept')->willReturn('application/json');
 
@@ -519,7 +519,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
             null,
             false,
             '',
-            $defaultTypes
+            $map
         );
 
         $factory->createResponse($this->request->reveal(), $status, 'detail');

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -24,6 +24,7 @@ use Zend\ProblemDetails\ProblemDetailsResponseFactory;
 use function array_keys;
 use function fclose;
 use function fopen;
+use function json_decode;
 use function stripos;
 
 class ProblemDetailsResponseFactoryTest extends TestCase
@@ -474,5 +475,56 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         );
 
         $this->assertSame($this->response->reveal(), $response);
+    }
+
+    public function provideMappedStatuses() : array
+    {
+        $defaultTypes = [
+            404 => 'https://example.com/problem-details/error/not-found',
+            500 => 'https://example.com/problem-details/error/internal-server-error',
+        ];
+
+        return [
+            [$defaultTypes, 404, 'https://example.com/problem-details/error/not-found'],
+            [$defaultTypes, 500, 'https://example.com/problem-details/error/internal-server-error'],
+            [$defaultTypes, 400, 'https://httpstatus.es/400'],
+            [[], 500, 'https://httpstatus.es/500'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMappedStatuses
+     */
+    public function testTypeIsInferredFromDefaultTypesMap(array $defaultTypes, int $status, string $expectedType) : void
+    {
+        $this->request->getHeaderLine('Accept')->willReturn('application/json');
+
+        $stream = $this->prophesize(StreamInterface::class);
+        $writeStream = $stream->write(Argument::that(function (string $body) use ($expectedType) {
+            $payload = json_decode($body, true);
+            Assert::assertEquals($expectedType, $payload['type']);
+
+            return $body;
+        }));
+
+        $this->response->getBody()->will([$stream, 'reveal']);
+        $witStatus = $this->response->withStatus($status)->will([$this->response, 'reveal']);
+        $this->response->withHeader('Content-Type', 'application/problem+json')->will([$this->response, 'reveal']);
+
+        $factory = new ProblemDetailsResponseFactory(
+            function () {
+                return $this->response->reveal();
+            },
+            false,
+            null,
+            false,
+            '',
+            $defaultTypes
+        );
+
+        $factory->createResponse($this->request->reveal(), $status, 'detail');
+
+        $writeStream->shouldHaveBeenCalled();
+        $witStatus->shouldHaveBeenCalled();
     }
 }

--- a/test/ProblemDetailsResponseFactoryTest.php
+++ b/test/ProblemDetailsResponseFactoryTest.php
@@ -508,7 +508,7 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         }));
 
         $this->response->getBody()->will([$stream, 'reveal']);
-        $witStatus = $this->response->withStatus($status)->will([$this->response, 'reveal']);
+        $withStatus = $this->response->withStatus($status)->will([$this->response, 'reveal']);
         $this->response->withHeader('Content-Type', 'application/problem+json')->will([$this->response, 'reveal']);
 
         $factory = new ProblemDetailsResponseFactory(
@@ -525,6 +525,6 @@ class ProblemDetailsResponseFactoryTest extends TestCase
         $factory->createResponse($this->request->reveal(), $status, 'detail');
 
         $writeStream->shouldHaveBeenCalled();
-        $witStatus->shouldHaveBeenCalled();
+        $withStatus->shouldHaveBeenCalled();
     }
 }


### PR DESCRIPTION
Closes #50 

A new configuration option is added, under `problem-details.default_types_map`, which can be used to define the value for the `type` property that should be used when it was not explicitly provided as part of the `ProblemDetailsResponseFactory::createResponse` call.

With this, users can customize the `type` value to be used when the `ProblemDetailsNotFoundHandler` is invoked or the `ProblemDetailsMiddleware` captures an exception not implementing `ProblemDetailsInterface`.